### PR TITLE
send_multi RC fix

### DIFF
--- a/tools/send_multi.c
+++ b/tools/send_multi.c
@@ -63,6 +63,7 @@ int main (int argc, char **argv) {
        otherwise its an error code (-1 - WARNING, -2 - CRITICAL, -3 - UNKNOWN) */
     if (rc >= 0) {
 	    gm_log( GM_LOG_INFO, "%d check_multi child check%s submitted\n", rc, (rc>1)?"s":"" );
+       rc=0; /* OK */
     } else {
 	    rc*=-1;
     }


### PR DESCRIPTION
Hi Sven,
send_multi did not exit with a proper nagios compliant RC in case of success.  The result were plenty of 
   Return code of 17 for check of service 'xyz was out of bounds
FIxed now.

Cheers,
-Matthias
