### PR TITLE
send_multi: message improvements

### DIFF
--- a/tools/send_multi.c
+++ b/tools/send_multi.c
@@ -286,7 +286,7 @@ int send_result() {
 void alarm_sighandler(int sig) {
     gm_log( GM_LOG_TRACE, "alarm_sighandler(%i)\n", sig );
 
-    printf("got no input! Send plugin output to stdin.\n");
+    printf("Timeout after %d seconds - got no input! Send plugin output to stdin.\n", mod_gm_opt->timeout);
 
     exit(EXIT_FAILURE);
 }


### PR DESCRIPTION
Hi Sven,

send_multi is too silent when the feeding check_multi has a problem, it only states:
WARNING: 0 check_multi child checks submitted

I now look for a ASCIIZ message in STDIN stream and provide this message instead, 
if there were no successful child checks parsed.

The only thing to get this working is to add a '2>&1' to the check_multi cmdline.

Cheers,
-Matthias
