### PR TITLE
single quotes in perfdata

### DIFF
--- a/tools/send_multi.c
+++ b/tools/send_multi.c
@@ -455,7 +455,18 @@ int read_child_check(char *bufstart, char *bufend, struct timeval * end_time) {
     } else if ((attribute3=read_multi_attribute(bufstart,bufend,"plugin")) == NULL) {
         return 0;
     } else {
-        snprintf( temp_buffer, sizeof( temp_buffer )-1, "%s%s|%s::%s::%s", decode_xml(attribute), decode_xml(error), mod_gm_opt->service, decode_xml(attribute3), decode_xml(attribute2));
+        attribute2 = trim(attribute2);
+        attribute2 = decode_xml(attribute2);
+
+        /* do we have a single quote performance label? 
+           then single quote the whole multi header */
+        if (*attribute2 == '\'') {
+            attribute2++;
+            snprintf( temp_buffer, sizeof( temp_buffer )-1, "%s%s|\'%s::%s::%s", decode_xml(attribute), decode_xml(error), mod_gm_opt->service, decode_xml(attribute3), decode_xml(attribute2));
+        /* normal header without single quotes */
+        } else {
+            snprintf( temp_buffer, sizeof( temp_buffer )-1, "%s%s|%s::%s::%s", decode_xml(attribute), decode_xml(error), mod_gm_opt->service, decode_xml(attribute3), decode_xml(attribute2));
+        }
     }
     mod_gm_opt->message=strdup(temp_buffer);
     gm_log( GM_LOG_TRACE, "mod_gm_opt->message: %s\n", mod_gm_opt->message);
@@ -486,9 +497,11 @@ char *decode_xml(char *string) {
             char c;
             char *enc_string;
     } dtab[] = {
-            { '>', "&gt;"  },
-            { '<', "&lt;"  },
-            { '&', "&amp;" },
+            { '>',  "&gt;"   },
+            { '<',  "&lt;"   },
+            { '&',  "&amp;"  },
+            { '\'', "&#039;" },
+            { '\|', "&#124;" },
     };
     int i;
     char *found;


### PR DESCRIPTION
Hi Sven,

these are the fixes for send_multi to add support for single quoted perfdata.

Cheers,
-Matthias
