### PR TITLE
fix linking of mod_gearman_worker

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -315,7 +315,7 @@ version:
 # order does matter for perl libs/includes (at least on centos 5)
 mod_gearman_worker$(EXEEXT): $(mod_gearman_worker_OBJECTS) $(perl_objects) $(mod_gearman_worker_DEPENDENCIES)
 	@rm -f mod_gearman_worker$(EXEEXT)
-	$(CCLD) $(AM_CFLAGS) $(CFLAGS) -o $@ $(mod_gearman_worker_OBJECTS) $(perl_objects) $(mod_gearman_worker_LDADD) $(LIBS) $(PERLLIB)
+	$(CCLD) $(AM_CFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $(mod_gearman_worker_OBJECTS) $(perl_objects) $(mod_gearman_worker_LDADD) $(LIBS) $(PERLLIB)
 
 01_utils$(EXEEXT): $(01_utils_OBJECTS) $(perl_objects) $(01_utils_DEPENDENCIES)
 	@rm -f 01_utils$(EXEEXT)


### PR DESCRIPTION
the nagios module is correctly linked but the worker was not, it missed the LDFLAGS used when libgearman is in a non-standard location.
