### PR TITLE
Fixed use of check_result's output_file_fp.

### DIFF
--- a/neb_module/mod_gearman.c
+++ b/neb_module/mod_gearman.c
@@ -590,7 +590,7 @@ static int handle_host_check( int event_type, void *data ) {
         chk_result->scheduled_check     = TRUE;
         chk_result->reschedule_check    = TRUE;
         chk_result->output_file         = 0;
-        chk_result->output_file_fd      = -1;
+        chk_result->output_file_fp      = NULL;
         chk_result->output              = strdup(temp_buffer);
         chk_result->return_code         = 2;
         chk_result->check_options       = CHECK_OPTION_NONE;
@@ -767,7 +767,7 @@ static int handle_svc_check( int event_type, void *data ) {
         chk_result->scheduled_check     = TRUE;
         chk_result->reschedule_check    = TRUE;
         chk_result->output_file         = 0;
-        chk_result->output_file_fd      = -1;
+        chk_result->output_file_fp      = NULL;
         chk_result->output              = strdup(temp_buffer);
         chk_result->return_code         = 2;
         chk_result->check_options       = CHECK_OPTION_NONE;

--- a/neb_module/result_thread.c
+++ b/neb_module/result_thread.c
@@ -170,7 +170,7 @@ void *get_results( gearman_job_st *job, void *context, size_t *result_size, gear
     chk_result->scheduled_check     = TRUE;
     chk_result->reschedule_check    = TRUE;
     chk_result->output_file         = 0;
-    chk_result->output_file_fp      = -1;
+    chk_result->output_file_fp      = NULL;
 
     chk_result->engine              = &mod_gearman_check_engine;
 


### PR DESCRIPTION
This was output_file_fd (integer) previously but now is a FILE pointer.
