### PR TITLE
Fix logrotate.d Path in Makefile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -255,9 +255,9 @@ install-config:
 	@echo "################################################################"
 	@echo ""
 	@echo " configuration:"
-	@echo "         neb module: $(DESTDIR)$(sysconfdir)/mod_gearman_neb.conf"
-	@echo "         worker:     $(DESTDIR)$(sysconfdir)/mod_gearman_worker.conf"
-	@echo "         logrotate.d:     $(DESTDIR)$(sysconfdir)/logrotate.d/mod_gearman_worker"
+	@echo "         neb module:  $(DESTDIR)$(sysconfdir)/mod_gearman_neb.conf"
+	@echo "         worker:      $(DESTDIR)$(sysconfdir)/mod_gearman_worker.conf"
+	@echo "         logrotate.d: $(DESTDIR)$(sysconfdir)/logrotate.d/mod_gearman_worker"
 	@echo ""
 	@echo "################################################################"
 


### PR DESCRIPTION
The Path for logrotate.d was wrong in the Makefile and caused the Config Directory logrotate.d to be in the wrong place.
For Example:
--sysconfdir=/etc => logrotate.d ending up in /
