### PR TITLE
Clean up Function install-data-local in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -237,14 +237,8 @@ install-data-local: install-local-state-dir $(install_p1file)
 	    echo " make install-config"; \
 	    echo ""; \
 	else \
-	    $(install_sh_PROGRAM) -m 644 etc/mod_gearman_neb.conf $(DESTDIR)$(sysconfdir)/mod_gearman_neb.conf; \
-	    $(install_sh_PROGRAM) -m 644 etc/mod_gearman_worker.conf $(DESTDIR)$(sysconfdir)/mod_gearman_worker.conf; \
+            make install-config; \
 	fi
-	@echo " configuration:"
-	@echo "         neb module: $(DESTDIR)$(sysconfdir)/mod_gearman_neb.conf"
-	@echo "         worker:     $(DESTDIR)$(sysconfdir)/mod_gearman_worker.conf"
-	@echo ""
-	@echo "################################################################"
 	$(RM) $(DESTDIR)$(pkglibdir)/mod_gearman.so
 
 


### PR DESCRIPTION
I have cleaned up the Function install-data-local to use install-config to install the default Config Files rather then installing them manually.
