### PR TITLE
Make the compiler happy

### DIFF
--- a/contrib/mod_gearman_mini_epn.c
+++ b/contrib/mod_gearman_mini_epn.c
@@ -64,6 +64,7 @@ int main(int argc, char **argv) {
 		perl_free(my_perl);
 		exit(exitstatus);
 	}
+	return 0;
 }
 
 int run_epn(char *command_line) {


### PR DESCRIPTION
Proposed small fix: missing return value for int main() (compiler complains about this).
