### PR TITLE
Added subsys lock to worker init script.

### DIFF
--- a/worker/initscript.in
+++ b/worker/initscript.in
@@ -20,8 +20,8 @@ DAEMON=%WORKERBIN%
 NAME=mod_gearman_worker
 CONFIG=%CONFIG_WORKER%
 PIDFILE=%PIDFILE%
-USER=%USER%
 LOCKFILE=/var/lock/subsys/$NAME
+USER=%USER%
 USERID=`id -u`
 
 # load extra environment variables
@@ -45,7 +45,9 @@ case "$1" in
             $CMD
         fi
         if [ $? -eq 0 ]; then
-            touch $LOCKFILE
+            if [ "$USERID" -eq 0 ]; then
+                touch $LOCKFILE
+            fi
             echo "OK"
         else
             echo "failed"
@@ -64,7 +66,9 @@ case "$1" in
             done
             ps -p $pid > /dev/null 2>&1;
             if [ $? -ne 0 ]; then
-                rm -f $LOCKFILE $PIDFILE
+                if [ "$USERID" -eq 0 ]; then
+                    rm -f $LOCKFILE $PIDFILE
+                fi
                 echo "OK"
                 exit 0;
             else


### PR DESCRIPTION
This is required on RHEL style machines to properly handle run level changes.

You can read about it in more detail here which isn't the best documentation I know but the best I could find that validates why this change is necessary.

http://www.redhat.com/magazine/008jun05/departments/tips_tricks/
