### PR TITLE
Initscript returns 0 when start fails

### DIFF
--- a/worker/initscript.in
+++ b/worker/initscript.in
@@ -51,6 +51,7 @@ case "$1" in
             echo "OK"
         else
             echo "failed"
+	    exit 1;
         fi
         ;;
     stop)


### PR DESCRIPTION
If, for instance, mod_gearman_worker can't write to his log, it will fail to start returning a debug message and word "fail".
The problem is the return code, that should be 1.
