### PR TITLE
unescape newlines so that core can parse short,long, and perf outputs correctly

### DIFF
--- a/neb_module/result_thread.c
+++ b/neb_module/result_thread.c
@@ -189,7 +189,7 @@ void *get_results( gearman_job_st *job, void *context, size_t *result_size, gear
                 chk_result->output = strdup("(null)");
             }
             else {
-                chk_result->output = strdup( value );
+                chk_result->output = replace_str(value, "\\n", "\n");
             }
         }
 


### PR DESCRIPTION
I found that the naemon and nagios 4 cores now expect the check's output to have unescaped newlines. In the core, the last parameter to parse_check_output was changed from TRUE to FALSE -- which says to unescape newlines -- in handle_async_host_check_result and handle_async_host_check_result. Checks that are handled by the core workers don't escape the output's newlines like they were in nagios 3. Since the outputs coming from mod_gearman were still escaping the newlines, the output was not being parsed into the short, long, and perf outputs correctly.
ex.
[1401404189.001360] [016.1] [pid=31301] *\* Handling async check result for host 'child1' from 'Mod-Gearman Worker @ naemon'...
[1401404189.001369] [016.2] [pid=31301]   Check Type:         Active
[1401404189.001378] [016.2] [pid=31301]   Check Options:      0
[1401404189.001444] [016.2] [pid=31301]   Scheduled Check?:   Yes
[1401404189.001453] [016.2] [pid=31301]   Reschedule Check?:  Yes
[1401404189.001461] [016.2] [pid=31301]   Exited OK?:         Yes
[1401404189.001469] [016.2] [pid=31301]   Exec Time:          0.009
[1401404189.001481] [016.2] [pid=31301]   Latency:            0.731
[1401404189.001492] [016.2] [pid=31301]   Return Status:      0
[1401404189.001500] [016.2] [pid=31301]   Output:             Short Output\nLong Ouput\n | stuff=22mb;\n
[1401404189.001514] [016.2] [pid=31301] Parsing check output...
[1401404189.001524] [016.2] [pid=31301] Short Output: Short Output\nLong Ouput\n
[1401404189.001532] [016.2] [pid=31301] Long Output:  NULL
[1401404189.001540] [016.2] [pid=31301] Perf Data:    stuff=22mb;\n

To solve this, I used the new replace_str function to unescape the newlines in the output before giving it to the core. With the patch, the output is now correctly parsed:

[1401404494.003561] [016.1] [pid=31811] *\* Handling async check result for host 'child1' from 'Mod-Gearman Worker @ naemon'...
[1401404494.003569] [016.2] [pid=31811]   Check Type:         Active
[1401404494.003577] [016.2] [pid=31811]   Check Options:      0
[1401404494.003584] [016.2] [pid=31811]   Scheduled Check?:   Yes
[1401404494.003591] [016.2] [pid=31811]   Reschedule Check?:  Yes
[1401404494.003598] [016.2] [pid=31811]   Exited OK?:         Yes
[1401404494.003605] [016.2] [pid=31811]   Exec Time:          0.005
[1401404494.003614] [016.2] [pid=31811]   Latency:            0.719
[1401404494.003623] [016.2] [pid=31811]   Return Status:      0
[1401404494.003630] [016.2] [pid=31811]   Output:             Short Output
Long Ouput
 | stuff=22mb;

[1401404494.003643] [016.2] [pid=31811] Parsing check output...
[1401404494.003652] [016.2] [pid=31811] Short Output: Short Output
[1401404494.003659] [016.2] [pid=31811] Long Output:  Long Ouput

[1401404494.003666] [016.2] [pid=31811] Perf Data:    stuff=22mb;

Let me know if you have any questions.
