### PR TITLE
Include stddef.h to compile against nagios4

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -39,6 +39,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/stat.h>
+#include <stddef.h>
 
 #include "polarssl/md5.h"
 #include "common.h"


### PR DESCRIPTION
Fixes compile error when compiling against nagios4.
