### PR TITLE
Updated for race condition

### DIFF
--- a/neb_module/mod_gearman.c
+++ b/neb_module/mod_gearman.c
@@ -64,7 +64,7 @@ static pthread_mutex_t mod_gm_result_list_mutex = PTHREAD_MUTEX_INITIALIZER;
 void *gearman_module_handle=NULL;
 gearman_client_st client;
 
-int send_now, result_threads_running;
+int send_now, result_threads_running, result_thread_num[GM_LISTSIZE];
 pthread_t result_thr[GM_LISTSIZE];
 char target_queue[GM_BUFFERSIZE];
 char temp_buffer[GM_BUFFERSIZE];
@@ -1162,7 +1162,8 @@ static void start_threads(void) {
         int x;
         for(x = 0; x < mod_gm_opt->result_workers; x++) {
             result_threads_running++;
-            pthread_create ( &result_thr[x], NULL, result_worker, (void *)&result_threads_running);
+            result_thread_num[x] = result_threads_running;
+            pthread_create ( &result_thr[x], NULL, result_worker, (void *)&result_thread_num[x]);
         }
     }
 }


### PR DESCRIPTION
When result_workers > 1, race condition exists causing threads to be not labeled properly for debugging. Example output when result_workers=4:

[2016-05-26 12:04:59][17802][TRACE] worker 3 started
[2016-05-26 12:04:59][17802][TRACE] worker 3 started
[2016-05-26 12:04:59][17802][TRACE] worker 4 started
[2016-05-26 12:04:59][17802][TRACE] worker 4 started
