### PR TITLE
update for GEARMAN_FUNCTION_MAX_SIZE

### DIFF
--- a/common/gearman_utils.c
+++ b/common/gearman_utils.c
@@ -139,7 +139,7 @@ int add_job_to_queue( gearman_client_st *client, gm_server_t * server_list[GM_LI
     struct timeval now;
 
     /* check too long queue names */
-    if(strlen(queue) > 63) {
+    if(strlen(queue) > 511) {
         gm_log( GM_LOG_ERROR, "queue name too long: '%s'\n", queue );
         return GM_ERROR;
     }

--- a/common/gearman_utils.c
+++ b/common/gearman_utils.c
@@ -139,14 +139,14 @@ int add_job_to_queue( gearman_client_st *client, gm_server_t * server_list[GM_LI
     struct timeval now;
 
     /* check too long queue names */
-    if(strlen(queue) > 511) {
+    if(strlen(queue) > GEARMAN_FUNCTION_MAX_SIZE - 1) {
         gm_log( GM_LOG_ERROR, "queue name too long: '%s'\n", queue );
         return GM_ERROR;
     }
 
     /* cut off to long uniq ids */
     free_uniq = 0;
-    if(uniq != NULL && strlen(uniq) > 63) {
+    if(uniq != NULL && strlen(uniq) > GEARMAN_MAX_UNIQUE_SIZE - 1) {
         uniq = md5sum(uniq);
         free_uniq = 1;
     }

--- a/t/02-full.c
+++ b/t/02-full.c
@@ -141,11 +141,11 @@ void send_big_jobs(int transportmode) {
               "/bin/hostname"
             );
     temp_buffer[sizeof( temp_buffer )-1]='\x0';
-    char * uniq = "something at least bigger than the 64 chars allowed by libgearman!";
+    char * uniq = "something at least bigger than the (GEARMAN_MAX_UNIQUE_SIZE) 64 chars allowed by libgearman!";
     int rt = add_job_to_queue( &client, mod_gm_opt->server_list, "service", uniq, temp_buffer, GM_JOB_PRIO_NORMAL, 1, transportmode, TRUE );
     ok(rt == GM_OK, "big uniq id sent successfully in mode %s", transportmode == GM_ENCODE_ONLY ? "base64" : "aes256");
 
-    char * queue = "something at least bigger than the 64 chars allowed by libgearman!";
+    char * queue = "something at least bigger than the (GEARMAN_FUNCTION_MAX_SIZE) 512 chars allowed by libgearman! aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     rt = add_job_to_queue( &client, mod_gm_opt->server_list, queue, uniq, temp_buffer, GM_JOB_PRIO_NORMAL, 1, transportmode, TRUE );
     ok(rt == GM_ERROR, "big queue sent unsuccessfully in mode %s", transportmode == GM_ENCODE_ONLY ? "base64" : "aes256");
 


### PR DESCRIPTION
GEARMAN_FUNCTION_MAX_SIZE is defined in libgearman/limits.h as 512, not 64

If you follow the code in gearmand:

(client.cc) gearman_client_add_task_[level]_background ->
(client.cc) add_task_ptr ->
(add.cc)
gearman_sting_t function = { gearman_string_param_cstr(function_name) }; [ which saves the string and the len into function, definition for gearman_string_param_cstr in libgearman/string.h ]
add_task ->
(add.cc)
if gearman_size(function) > GEARMAN_FUNCTION_MAX_SIZE

I subtracted 1 much like the 1 subtracted from GEARMAN_MAX_UNIQUE_SIZE
