### PR TITLE
Memory leak

### DIFF
--- a/neb_module/mod_gearman.c
+++ b/neb_module/mod_gearman.c
@@ -723,8 +723,9 @@ static int handle_host_check( int event_type, void *data ) {
     else {
         my_free(raw_command);
         my_free(processed_command);
+#if defined(USENAEMON)
         clear_volatile_macros_r(&mac);
-
+#endif
         /* unset the execution flag */
         hst->is_executing=FALSE;
 
@@ -948,8 +949,10 @@ static int handle_svc_check( int event_type, void *data ) {
     /* clean up */
     my_free(raw_command);
     my_free(processed_command);
+#if defined(USENAEMON)
     clear_volatile_macros_r(&mac);
-
+#endif
+    
     /* orphaned check - submit fake result to mark service as orphaned */
 #ifdef USENAGIOS
     if(mod_gm_opt->orphan_service_checks == GM_ENABLED && svc->check_options & CHECK_OPTION_ORPHAN_CHECK) {

--- a/neb_module/mod_gearman.c
+++ b/neb_module/mod_gearman.c
@@ -723,6 +723,7 @@ static int handle_host_check( int event_type, void *data ) {
     else {
         my_free(raw_command);
         my_free(processed_command);
+        clear_volatile_macros_r(&mac);
 
         /* unset the execution flag */
         hst->is_executing=FALSE;
@@ -947,6 +948,7 @@ static int handle_svc_check( int event_type, void *data ) {
     /* clean up */
     my_free(raw_command);
     my_free(processed_command);
+    clear_volatile_macros_r(&mac);
 
     /* orphaned check - submit fake result to mark service as orphaned */
 #ifdef USENAGIOS


### PR DESCRIPTION
Hi sven,
I think there's a heavy memory leak around processing macros.

process_macros_r function mallocs et reallocs many times (stored in mac structure) but these allocations are never deallocated in both handle_host_check nor handle_service_check when cleaning memory at end.

Before this update, naemon was losing about 1 Mo/minute (1000 hosts, 10000 services).
With my update, running now for 24 hours, naemon stays a 20 Mo without any leak.

What do you think about ?

jfr