### PR TITLE
logrotate pointing to wrong init script

### DIFF
--- a/etc/mod_gearman_logrotate
+++ b/etc/mod_gearman_logrotate
@@ -1,9 +1,9 @@
-/var/log/mod_gearman/mod_gearman_worker.log {
+/var/log/mod_gearman/worker.log {
     missingok
     notifempty
     sharedscripts
     postrotate
-        /etc/init.d/mod_gearman_worker reload > /dev/null 2>/dev/null || true
+        /etc/init.d/mod-gearman-worker reload > /dev/null 2>/dev/null || true
     endscript
     compress
 }

--- a/etc/mod_gearman_logrotate
+++ b/etc/mod_gearman_logrotate
@@ -1,4 +1,4 @@
-/var/log/mod_gearman/worker.log {
+/var/log/mod_gearman/mod_gearman_worker.log {
     missingok
     notifempty
     sharedscripts


### PR DESCRIPTION
 Logrorate config is pointing to the old init script used by mod_gearman 1.x.