### PR TITLE
Fixes #133

### DIFF
--- a/common/gearman_utils.c
+++ b/common/gearman_utils.c
@@ -68,35 +68,6 @@ int worker_add_function( gearman_worker_st * worker, char * queue, gearman_worke
 }
 
 
-/* create the gearman duplicate client */
-int create_client_dup( gm_server_t * server_list[GM_LISTSIZE], gearman_client_st *client ) {
-    gearman_return_t ret;
-    int x = 0;
-
-    gm_log( GM_LOG_TRACE, "create_client_dup()\n" );
-
-    signal(SIGPIPE, SIG_IGN);
-
-    client = gearman_client_create(client);
-    if ( client == NULL ) {
-        gm_log( GM_LOG_ERROR, "Memory allocation failure on client creation\n" );
-        return GM_ERROR;
-    }
-
-    while ( server_list[x] != NULL ) {
-        ret = gearman_client_add_server( client, server_list[x]->host, server_list[x]->port );
-        if ( ret != GEARMAN_SUCCESS ) {
-            gm_log( GM_LOG_ERROR, "client error: %s\n", gearman_client_error( client ) );
-            return GM_ERROR;
-        }
-        x++;
-    }
-
-    current_client_dup = client;
-
-    return GM_OK;
-}
-
 /* create the gearman client */
 int create_client( gm_server_t * server_list[GM_LISTSIZE], gearman_client_st *client ) {
     gearman_return_t ret;
@@ -123,7 +94,6 @@ int create_client( gm_server_t * server_list[GM_LISTSIZE], gearman_client_st *cl
     assert(x != 0);
 
     gearman_client_set_timeout( client, mod_gm_opt->gearman_connection_timeout );
-    current_client = client;
 
     return GM_OK;
 }

--- a/include/gearman_utils.h
+++ b/include/gearman_utils.h
@@ -50,7 +50,6 @@ gearman_client_st *current_client_dup;
 gearman_job_st *current_gearman_job;
 
 int create_client( gm_server_t * server_list[GM_LISTSIZE], gearman_client_st * client);
-int create_client_dup( gm_server_t * server_list[GM_LISTSIZE], gearman_client_st * client);
 int create_worker( gm_server_t * server_list[GM_LISTSIZE], gearman_worker_st * worker);
 int add_job_to_queue( gearman_client_st *client, gm_server_t * server_list[GM_LISTSIZE], char * queue, char * uniq, char * data, int priority, int retries, int transport_mode, int send_now );
 int worker_add_function( gearman_worker_st * worker, char * queue, gearman_worker_fn *function);

--- a/neb_module/mod_gearman.c
+++ b/neb_module/mod_gearman.c
@@ -177,9 +177,11 @@ int nebmodule_init( int flags, char *args, nebmodule *handle ) {
 
     /* create client */
     if ( create_client( mod_gm_opt->server_list, &client ) != GM_OK ) {
+        current_client = &client;
         gm_log( GM_LOG_ERROR, "cannot start client\n" );
         return NEB_ERROR;
     }
+    current_client = &client;
 
     /* register callback for process event where everything else starts */
     neb_register_callback( NEBCALLBACK_PROCESS_DATA, gearman_module_handle, 0, handle_process_events );

--- a/tools/check_gearman.c
+++ b/tools/check_gearman.c
@@ -332,9 +332,11 @@ int check_worker(char * queue, char * to_send, char * expect) {
 
     /* create client */
     if ( create_client( server_list, &client ) != GM_OK ) {
+        current_client = &client;
         printf("%s UNKNOWN - cannot create gearman client\n", PLUGIN_NAME);
         return( STATE_UNKNOWN );
     }
+    current_client = &client;
     gearman_client_set_timeout(&client, (opt_timeout-1)*1000/server_list_num);
 
     while (1) {

--- a/tools/send_gearman.c
+++ b/tools/send_gearman.c
@@ -61,12 +61,14 @@ int main (int argc, char **argv) {
         printf( "send_gearman UNKNOWN: cannot start client\n" );
         exit( STATE_UNKNOWN );
     }
+    current_client = &client;
 
     /* create duplicate client */
-    if ( create_client_dup( mod_gm_opt->dupserver_list, &client_dup ) != GM_OK ) {
+    if ( create_client( mod_gm_opt->dupserver_list, &client_dup ) != GM_OK ) {
         printf( "send_gearman UNKNOWN: cannot start client for duplicate server\n" );
         exit( STATE_UNKNOWN );
     }
+    current_client_dup = &client;
 
     /* send result message */
     signal(SIGALRM, alarm_sighandler);

--- a/tools/send_gearman.c
+++ b/tools/send_gearman.c
@@ -64,9 +64,11 @@ int main (int argc, char **argv) {
     current_client = &client;
 
     /* create duplicate client */
-    if ( create_client( mod_gm_opt->dupserver_list, &client_dup ) != GM_OK ) {
-        printf( "send_gearman UNKNOWN: cannot start client for duplicate server\n" );
-        exit( STATE_UNKNOWN );
+    if ( mod_gm_opt->dupserver_num > 0 ) {
+        if ( create_client( mod_gm_opt->dupserver_list, &client_dup ) != GM_OK ) {
+            printf( "send_gearman UNKNOWN: cannot start client for duplicate server\n" );
+            exit( STATE_UNKNOWN );
+        }
     }
     current_client_dup = &client;
 

--- a/tools/send_multi.c
+++ b/tools/send_multi.c
@@ -64,9 +64,11 @@ int main (int argc, char **argv) {
     current_client = &client;
 
     /* create duplicate client */
-    if ( create_client( mod_gm_opt->dupserver_list, &client_dup ) != GM_OK ) {
-        printf( "send_multi UNKNOWN: cannot start client for duplicate server\n" );
-        exit( STATE_UNKNOWN );
+    if ( mod_gm_opt->dupserver_num > 0 ) {
+        if ( create_client( mod_gm_opt->dupserver_list, &client_dup ) != GM_OK ) {
+            printf( "send_multi UNKNOWN: cannot start client for duplicate server\n" );
+            exit( STATE_UNKNOWN );
+        }
     }
     current_client_dup = &client_dup;
 

--- a/tools/send_multi.c
+++ b/tools/send_multi.c
@@ -61,12 +61,14 @@ int main (int argc, char **argv) {
         printf( "send_multi UNKNOWN: cannot start client\n" );
         exit( STATE_UNKNOWN );
     }
+    current_client = &client;
 
     /* create duplicate client */
-    if ( create_client_dup( mod_gm_opt->dupserver_list, &client_dup ) != GM_OK ) {
+    if ( create_client( mod_gm_opt->dupserver_list, &client_dup ) != GM_OK ) {
         printf( "send_multi UNKNOWN: cannot start client for duplicate server\n" );
         exit( STATE_UNKNOWN );
     }
+    current_client_dup = &client_dup;
 
     /* send result message */
     signal(SIGALRM, alarm_sighandler);

--- a/worker/worker_client.c
+++ b/worker/worker_client.c
@@ -78,13 +78,15 @@ void worker_client(int worker_mode, int indx, int shid) {
         clean_worker_exit(0);
         _exit( EXIT_FAILURE );
     }
+    current_client = &client;
 
     /* create duplicate client */
     if( mod_gm_opt->dupserver_num ) {
-        if ( create_client_dup( mod_gm_opt->dupserver_list, &client_dup ) != GM_OK ) {
+        if ( create_client( mod_gm_opt->dupserver_list, &client_dup ) != GM_OK ) {
             gm_log( GM_LOG_ERROR, "cannot start client for duplicate server\n" );
             _exit( EXIT_FAILURE );
         }
+        current_client_dup = &client_dup;
     }
 
 #ifdef EMBEDDEDPERL
@@ -137,8 +139,11 @@ void worker_loop() {
             /* create new connections */
             set_worker( &worker );
             create_client( mod_gm_opt->server_list, &client );
-            if( mod_gm_opt->dupserver_num )
-                create_client_dup( mod_gm_opt->dupserver_list, &client_dup );
+            current_client = &client;
+            if( mod_gm_opt->dupserver_num ) {
+                create_client( mod_gm_opt->dupserver_list, &client_dup );
+                current_client_dup = &client_dup;
+            }
         }
     }
 


### PR DESCRIPTION
Previously when the dupserver gearmand instance fails the retry would override `current_client` with `current_client_dup` leading to results being missed by the non-dupservers.

We've changed it so that `create_client` no longer sets `current_client` and the logic for setting this has been pushed to the consumer of the `create_client` function. This means we can delete `create_client_dup`; this also means that the timeout is now set for dupserver clients.

This *may* also fix #111 as it looks similar in behaviour