### PR TITLE
Accidentally broke sending to dupservers

### DIFF
--- a/tools/send_gearman.c
+++ b/tools/send_gearman.c
@@ -70,7 +70,7 @@ int main (int argc, char **argv) {
             exit( STATE_UNKNOWN );
         }
     }
-    current_client_dup = &client;
+    current_client_dup = &client_dup;
 
     /* send result message */
     signal(SIGALRM, alarm_sighandler);


### PR DESCRIPTION
Apologies @sni, we just noticed that we'd accidentally overwritten the current_client_dup with the non-dup client in send_gearman; this fixes it