### PR TITLE
Reducing the CPU time blocked by mod_gearman in the main loop of Naemon

### DIFF
--- a/common/gm_crypt.c
+++ b/common/gm_crypt.c
@@ -45,6 +45,28 @@ unsigned char key[KEYBYTES];
 static THREAD_LOCAL EVP_MD_CTX *mdctx  = NULL;
 static const char hex[] = "0123456789ABCDEF";
 
+/* under openssl 3 the legacy EVP_aes_256_ecb()/EVP_md5() pointers make every
+ * Init_ex() look the implementation up in the provider registry again, so
+ * fetch them once. thread local because results are decrypted on own threads. */
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+static THREAD_LOCAL EVP_CIPHER *gm_aes256ecb = NULL;
+static THREAD_LOCAL EVP_MD     *gm_md5       = NULL;
+
+static const EVP_CIPHER *gm_get_aes256ecb(void) {
+    if(gm_aes256ecb == NULL)
+        gm_aes256ecb = EVP_CIPHER_fetch(NULL, "AES-256-ECB", NULL);
+    return gm_aes256ecb;
+}
+static const EVP_MD *gm_get_md5(void) {
+    if(gm_md5 == NULL)
+        gm_md5 = EVP_MD_fetch(NULL, "MD5", NULL);
+    return gm_md5;
+}
+#else
+#define gm_get_aes256ecb() EVP_aes_256_ecb()
+#define gm_get_md5()       EVP_md5()
+#endif
+
 /* initialize encryption */
 EVP_CIPHER_CTX * mod_gm_aes_init(const char * password) {
     EVP_CIPHER_CTX * ctx;
@@ -84,7 +106,7 @@ int mod_gm_aes_encrypt(EVP_CIPHER_CTX * ctx, unsigned char * ciphertext, const u
 
     assert(ctx != NULL);
 
-    if(1 != EVP_EncryptInit_ex(ctx, EVP_aes_256_ecb(), NULL, key, NULL)) {
+    if(1 != EVP_EncryptInit_ex(ctx, gm_get_aes256ecb(), NULL, key, NULL)) {
         fprintf(stderr, "EVP_EncryptInit_ex failed:\n");
         ERR_print_errors_fp(stderr);
         return -1;
@@ -125,7 +147,7 @@ int mod_gm_aes_decrypt(EVP_CIPHER_CTX * ctx, unsigned char * plaintext, unsigned
 
     assert(ctx != NULL);
 
-    if(1 != EVP_DecryptInit_ex(ctx, EVP_aes_256_ecb(), NULL, key, NULL)) {
+    if(1 != EVP_DecryptInit_ex(ctx, gm_get_aes256ecb(), NULL, key, NULL)) {
         fprintf(stderr, "EVP_DecryptInit_ex failed\n");
         ERR_print_errors_fp(stderr);
         return -1;
@@ -169,7 +191,7 @@ void mod_gm_hexsum(char *dest, char *text) {
         fprintf(stderr, "failed to initialize MD5 context\n");
         exit(1);
     }
-    if(EVP_DigestInit_ex(mdctx, EVP_md5(), NULL) != 1 || EVP_DigestUpdate(mdctx, text, strlen(text)) != 1 || EVP_DigestFinal_ex(mdctx, result, &resultlen) != 1) {
+    if(EVP_DigestInit_ex(mdctx, gm_get_md5(), NULL) != 1 || EVP_DigestUpdate(mdctx, text, strlen(text)) != 1 || EVP_DigestFinal_ex(mdctx, result, &resultlen) != 1) {
         fprintf(stderr, "MD5 computation failed\n");
         exit(1);
     }

--- a/common/gm_crypt.c
+++ b/common/gm_crypt.c
@@ -106,7 +106,14 @@ int mod_gm_aes_encrypt(EVP_CIPHER_CTX * ctx, unsigned char * ciphertext, const u
 
     assert(ctx != NULL);
 
-    if(1 != EVP_EncryptInit_ex(ctx, gm_get_aes256ecb(), NULL, key, NULL)) {
+    const EVP_CIPHER *cipher = gm_get_aes256ecb();
+    if(cipher == NULL) {
+        fprintf(stderr, "EVP_CIPHER_fetch(AES-256-ECB) failed:\n");
+        ERR_print_errors_fp(stderr);
+        return -1;
+    }
+
+    if(1 != EVP_EncryptInit_ex(ctx, cipher, NULL, key, NULL)) {
         fprintf(stderr, "EVP_EncryptInit_ex failed:\n");
         ERR_print_errors_fp(stderr);
         return -1;
@@ -191,7 +198,15 @@ void mod_gm_hexsum(char *dest, char *text) {
         fprintf(stderr, "failed to initialize MD5 context\n");
         exit(1);
     }
-    if(EVP_DigestInit_ex(mdctx, gm_get_md5(), NULL) != 1 || EVP_DigestUpdate(mdctx, text, strlen(text)) != 1 || EVP_DigestFinal_ex(mdctx, result, &resultlen) != 1) {
+
+    const EVP_MD *md = gm_get_md5();
+    if(md == NULL) {
+        fprintf(stderr, "EVP_MD_fetch(MD5) failed:\n");
+        ERR_print_errors_fp(stderr);
+        exit(1);
+    }
+
+    if(EVP_DigestInit_ex(mdctx, md, NULL) != 1 || EVP_DigestUpdate(mdctx, text, strlen(text)) != 1 || EVP_DigestFinal_ex(mdctx, result, &resultlen) != 1) {
         fprintf(stderr, "MD5 computation failed\n");
         exit(1);
     }

--- a/common/utils.c
+++ b/common/utils.c
@@ -1513,13 +1513,18 @@ static void gm_log_body( int lvl, const char *text, va_list ap_in );
 void gm_log( int lvl, const char *text, ... ) {
     va_list ap;
     int debug_level = GM_LOG_ERROR;
+    int logmode     = GM_LOG_MODE_STDOUT;
 
-    if(mod_gm_opt != NULL)
+    if(mod_gm_opt != NULL) {
         debug_level = mod_gm_opt->debug_level;
+        logmode     = mod_gm_opt->logmode;
+    }
+
+    if ( logmode == GM_LOG_MODE_CORE && debug_level < 0 )
+        return;
 
     if ( lvl != GM_LOG_ERROR && lvl > debug_level )
         return;
-
     va_start( ap, text );
     gm_log_body( lvl, text, ap );
     va_end( ap );

--- a/common/utils.c
+++ b/common/utils.c
@@ -1543,6 +1543,7 @@ static void gm_log_body( int lvl, const char *text, va_list ap_in ) {
     struct timeval tv;
     struct tm now;
     bool locked = false;
+    va_list ap_copy;
 
     if(mod_gm_opt != NULL) {
         debug_level = mod_gm_opt->debug_level;
@@ -1560,7 +1561,9 @@ static void gm_log_body( int lvl, const char *text, va_list ap_in ) {
         } else {
             snprintf( buffer1, 14, "mod_gearman: " );
         }
-        vsnprintf( buffer1 + strlen( buffer1 ), sizeof( buffer1 ) - strlen( buffer1 ), text, ap_in );
+        va_copy(ap_copy, ap_in);
+        vsnprintf( buffer1 + strlen( buffer1 ), sizeof( buffer1 ) - strlen( buffer1 ), text, ap_copy );
+        va_end(ap_copy);
 
         if ( debug_level >= GM_LOG_STDOUT ) {
             printf( "%s", buffer1 );
@@ -1603,7 +1606,9 @@ static void gm_log_body( int lvl, const char *text, va_list ap_in ) {
     /* append milliseconds and pid */
     snprintf(buffer2, sizeof(buffer2), ",%03ld][%i][%s]", tv.tv_usec/1000, getpid(), level);
 
-    vsnprintf( buffer3, GM_BUFFERSIZE, text, ap_in );
+    va_copy(ap_copy, ap_in);
+    vsnprintf( buffer3, GM_BUFFERSIZE, text, ap_copy );
+    va_end(ap_copy);
 
     if ( debug_level >= GM_LOG_STDOUT || logmode == GM_LOG_MODE_CHECKS ) {
         fprintf(stderr, "%s", buffer3 );

--- a/common/utils.c
+++ b/common/utils.c
@@ -1507,7 +1507,26 @@ char *replace_str(const char *str, const char *old, const char *new) {
 }
 
 /* generic logger function */
+static void gm_log_body( int lvl, const char *text, va_list ap_in );
+
+/* the body needs a 192kb stack frame, so filter the level out before entering it */
 void gm_log( int lvl, const char *text, ... ) {
+    va_list ap;
+    int debug_level = GM_LOG_ERROR;
+
+    if(mod_gm_opt != NULL)
+        debug_level = mod_gm_opt->debug_level;
+
+    if ( lvl != GM_LOG_ERROR && lvl > debug_level )
+        return;
+
+    va_start( ap, text );
+    gm_log_body( lvl, text, ap );
+    va_end( ap );
+}
+
+__attribute__((noinline))
+static void gm_log_body( int lvl, const char *text, va_list ap_in ) {
     FILE * fp       = NULL;
     int debug_level = GM_LOG_ERROR;
     int logmode     = GM_LOG_MODE_STDOUT;
@@ -1518,7 +1537,6 @@ void gm_log( int lvl, const char *text, ... ) {
     char buffer3[GM_BUFFERSIZE];
     struct timeval tv;
     struct tm now;
-    va_list ap;
     bool locked = false;
 
     if(mod_gm_opt != NULL) {
@@ -1537,9 +1555,7 @@ void gm_log( int lvl, const char *text, ... ) {
         } else {
             snprintf( buffer1, 14, "mod_gearman: " );
         }
-        va_start( ap, text );
-        vsnprintf( buffer1 + strlen( buffer1 ), sizeof( buffer1 ) - strlen( buffer1 ), text, ap );
-        va_end( ap );
+        vsnprintf( buffer1 + strlen( buffer1 ), sizeof( buffer1 ) - strlen( buffer1 ), text, ap_in );
 
         if ( debug_level >= GM_LOG_STDOUT ) {
             printf( "%s", buffer1 );
@@ -1582,9 +1598,7 @@ void gm_log( int lvl, const char *text, ... ) {
     /* append milliseconds and pid */
     snprintf(buffer2, sizeof(buffer2), ",%03ld][%i][%s]", tv.tv_usec/1000, getpid(), level);
 
-    va_start( ap, text );
-    vsnprintf( buffer3, GM_BUFFERSIZE, text, ap );
-    va_end( ap );
+    vsnprintf( buffer3, GM_BUFFERSIZE, text, ap_in );
 
     if ( debug_level >= GM_LOG_STDOUT || logmode == GM_LOG_MODE_CHECKS ) {
         fprintf(stderr, "%s", buffer3 );


### PR DESCRIPTION
As you know I'm currently playing around with Claude AI to profile the Naemon Event Loop. The goal is to reduce the amount of CPU time consumed by the Naemon Main Loop to get a higher check throughput per second.

My test setup is Naemon 1.5.2 (with some performance patches), 5k hosts, 100k services at 60s check interval. Profiling is done with loaded mod_gearman and/or statusengine broker.

Claude found two easy to fix issue:

##  `gm_log()` in `common/utils.c` - 14.27% => 0.77%

The function declares three `GM_BUFFERSIZE` (64kb) buffers, so every call builds a 192kb stack frame *before* it looks at the log level. The check submission path calls it at `GM_LOG_TRACE`, which at the default `debug=0` does nothing but return after paying for the frame.

##  OpenSSL lookups in `common/gm_crypt.c` - 8.39% => <0.03%

`EVP_aes_256_ecb()` is passed to `EVP_EncryptInit_ex()` for every job, and `EVP_md5()` to `EVP_DigestInit_ex()` for every gearman uniq id. Under OpenSSL 3 those legacy pointers make each `Init_ex()` look the implementation up in the
provider registry again:
- `EVP_CIPHER_fetch` 3.63% => <0.01%
- `EVP_MD_fetch` 2.67% => <0.01%
- `OPENSSL_LH_retrieve` 2.09% => <0.01%

Both are now fetched once per thread and reused, behind a version guard so OpenSSL 1.x builds are unchanged.

## Result

| | event loop CPU per 60s |
|---|---|
| v5.2.4 | 8.12s |
| + logging fix | 7.32s (−9.8%) |
| + openssl fix | 6.95s (−14% total) |

Encryption compatibility was verified against an unmodified `mod-gearman-worker-go`. It still decrypts every job.

As mentioned this was found and patched by AI. I leave it up to you if you want to merge this, copy&paste it over or throw it in the bin all together. I also discovered another time consuming (IO-WAIT, not CPU time) call, which is blocking Naemon. But this is a larger code change so I will submit it in a second PR.