### PR TITLE
Refactor to async job submission

### DIFF
--- a/common/gearman_utils.c
+++ b/common/gearman_utils.c
@@ -319,7 +319,9 @@ submit_done:
         }
 
         /* recreate client, otherwise gearman sigsegvs */
-        gm_release_pending();
+        if(async) {
+            gm_release_pending();
+        }
         gm_free_client(client);
         if(async) {
             *client = create_client(server_list);

--- a/common/gearman_utils.c
+++ b/common/gearman_utils.c
@@ -120,6 +120,59 @@ gearman_client_st * create_client_blocking( gm_server_t * server_list[GM_LISTSIZ
 }
 
 
+/*
+ * Pipelined background submits.
+ *
+ * gearman_client_do_background() waits for the JOB_CREATED reply, which costs a
+ * round-trip per job on the caller's thread. For check submissions that thread
+ * is the naemon event loop, so the wait is time it cannot spend dispatching.
+ *
+ * In async mode the task is only queued here and driven on the next call or by
+ * the periodic flush, so the round-trip overlaps with the core's own work.
+ * Bounded: once GM_MAX_PENDING_SUBMITS are in flight we flush synchronously,
+ * which is exactly the old behaviour and keeps this from growing without limit
+ * when gearmand stalls.
+ *
+ * The payloads are held until a flush reports all tasks done. libgearman does
+ * not document whether it copies the workload, so we keep it alive rather than
+ * depend on it.
+ */
+#define GM_MAX_PENDING_SUBMITS 64
+static char         *gm_pending_data[GM_MAX_PENDING_SUBMITS];
+static unsigned int  gm_pending_submits = 0;
+
+static void gm_release_pending(void) {
+    unsigned int i;
+    for(i = 0; i < gm_pending_submits; i++) {
+        free(gm_pending_data[i]);
+        gm_pending_data[i] = NULL;
+    }
+    gm_pending_submits = 0;
+}
+
+int gm_flush_submits(gearman_client_st *client, int blocking) {
+    gearman_return_t rc;
+
+    if(client == NULL || gm_pending_submits == 0)
+        return GM_OK;
+
+    if(blocking)
+        gearman_client_remove_options(client, GEARMAN_CLIENT_NON_BLOCKING);
+    rc = gearman_client_run_tasks(client);
+    if(blocking)
+        gearman_client_add_options(client, GEARMAN_CLIENT_NON_BLOCKING);
+
+    if(rc == GEARMAN_SUCCESS) {
+        /* every task finished, so the payloads are no longer referenced */
+        gm_release_pending();
+        return GM_OK;
+    }
+    if(rc == GEARMAN_IO_WAIT)
+        return GM_OK;
+
+    return GM_ERROR;
+}
+
 /* create a task and send it */
 int add_job_to_queue(gearman_client_st **client, gm_server_t * server_list[GM_LISTSIZE], char * queue, char * uniq, char * data, int priority, int retries, int transport_mode, EVP_CIPHER_CTX * ctx, int async, int log_stats_interval) {
     gearman_job_handle_t job_handle;
@@ -153,20 +206,67 @@ int add_job_to_queue(gearman_client_st **client, gm_server_t * server_list[GM_LI
     }
     gm_log( GM_LOG_TRACE, "%d +++>\n%s\n<+++\n", size, crypted_data );
 
-    if( priority == GM_JOB_PRIO_LOW ) {
-        rc = gearman_client_do_low_background(*client, queue, uniq, ( void * )crypted_data, ( size_t )size, job_handle);
-    }
-    else if( priority == GM_JOB_PRIO_NORMAL ) {
-        rc = gearman_client_do_background(*client, queue, uniq, ( void * )crypted_data, ( size_t )size, job_handle);
-    }
-    else if( priority == GM_JOB_PRIO_HIGH ) {
-        rc = gearman_client_do_high_background(*client, queue, uniq, ( void * )crypted_data, ( size_t )size, job_handle);
+    if(async) {
+        /*
+         * Reap whatever the previous calls left in flight. If that fails the
+         * connection is gone, and libgearman must not be called again on this
+         * client -- run_tasks() segfaults on a client that already errored.
+         * Fall through to the recreate path below instead.
+         */
+        if(gm_flush_submits(*client, FALSE) != GM_OK) {
+            free(crypted_data);
+            rc = GEARMAN_ERRNO;
+            goto submit_done;
+        }
+
+        if( priority == GM_JOB_PRIO_LOW ) {
+            gearman_client_add_task_low_background(*client, NULL, NULL, queue, uniq, ( void * )crypted_data, ( size_t )size, &rc);
+        }
+        else if( priority == GM_JOB_PRIO_NORMAL ) {
+            gearman_client_add_task_background(*client, NULL, NULL, queue, uniq, ( void * )crypted_data, ( size_t )size, &rc);
+        }
+        else if( priority == GM_JOB_PRIO_HIGH ) {
+            gearman_client_add_task_high_background(*client, NULL, NULL, queue, uniq, ( void * )crypted_data, ( size_t )size, &rc);
+        }
+        else {
+            gm_log( GM_LOG_ERROR, "add_job_to_queue() wrong priority: %d\n", priority );
+            free(crypted_data);
+            return GM_ERROR;
+        }
+
+        if(rc == GEARMAN_SUCCESS || rc == GEARMAN_IO_WAIT) {
+            gm_pending_data[gm_pending_submits++] = crypted_data;
+            /* push it out now, but do not wait for the reply */
+            if(gm_flush_submits(*client, FALSE) != GM_OK) {
+                rc = GEARMAN_ERRNO;
+            }
+            else if(gm_pending_submits >= GM_MAX_PENDING_SUBMITS) {
+                /* too many in flight: fall back to waiting, as before */
+                if(gm_flush_submits(*client, TRUE) != GM_OK)
+                    rc = GEARMAN_ERRNO;
+            }
+        } else {
+            free(crypted_data);
+        }
     }
     else {
-        gm_log( GM_LOG_ERROR, "add_job_to_queue() wrong priority: %d\n", priority );
-        return GM_ERROR;
+        if( priority == GM_JOB_PRIO_LOW ) {
+            rc = gearman_client_do_low_background(*client, queue, uniq, ( void * )crypted_data, ( size_t )size, job_handle);
+        }
+        else if( priority == GM_JOB_PRIO_NORMAL ) {
+            rc = gearman_client_do_background(*client, queue, uniq, ( void * )crypted_data, ( size_t )size, job_handle);
+        }
+        else if( priority == GM_JOB_PRIO_HIGH ) {
+            rc = gearman_client_do_high_background(*client, queue, uniq, ( void * )crypted_data, ( size_t )size, job_handle);
+        }
+        else {
+            gm_log( GM_LOG_ERROR, "add_job_to_queue() wrong priority: %d\n", priority );
+            free(crypted_data);
+            return GM_ERROR;
+        }
+        free(crypted_data);
     }
-    free(crypted_data);
+submit_done:
     gettimeofday(&t2,NULL);
 
     // log some statistics
@@ -219,6 +319,7 @@ int add_job_to_queue(gearman_client_st **client, gm_server_t * server_list[GM_LI
         }
 
         /* recreate client, otherwise gearman sigsegvs */
+        gm_release_pending();
         gm_free_client(client);
         if(async) {
             *client = create_client(server_list);

--- a/common/gm_crypt.c
+++ b/common/gm_crypt.c
@@ -45,6 +45,28 @@ unsigned char key[KEYBYTES];
 static THREAD_LOCAL EVP_MD_CTX *mdctx  = NULL;
 static const char hex[] = "0123456789ABCDEF";
 
+/* under openssl 3 the legacy EVP_aes_256_ecb()/EVP_md5() pointers make every
+ * Init_ex() look the implementation up in the provider registry again, so
+ * fetch them once. thread local because results are decrypted on own threads. */
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+static THREAD_LOCAL EVP_CIPHER *gm_aes256ecb = NULL;
+static THREAD_LOCAL EVP_MD     *gm_md5       = NULL;
+
+static const EVP_CIPHER *gm_get_aes256ecb(void) {
+    if(gm_aes256ecb == NULL)
+        gm_aes256ecb = EVP_CIPHER_fetch(NULL, "AES-256-ECB", NULL);
+    return gm_aes256ecb;
+}
+static const EVP_MD *gm_get_md5(void) {
+    if(gm_md5 == NULL)
+        gm_md5 = EVP_MD_fetch(NULL, "MD5", NULL);
+    return gm_md5;
+}
+#else
+#define gm_get_aes256ecb() EVP_aes_256_ecb()
+#define gm_get_md5()       EVP_md5()
+#endif
+
 /* initialize encryption */
 EVP_CIPHER_CTX * mod_gm_aes_init(const char * password) {
     EVP_CIPHER_CTX * ctx;
@@ -84,7 +106,7 @@ int mod_gm_aes_encrypt(EVP_CIPHER_CTX * ctx, unsigned char * ciphertext, const u
 
     assert(ctx != NULL);
 
-    if(1 != EVP_EncryptInit_ex(ctx, EVP_aes_256_ecb(), NULL, key, NULL)) {
+    if(1 != EVP_EncryptInit_ex(ctx, gm_get_aes256ecb(), NULL, key, NULL)) {
         fprintf(stderr, "EVP_EncryptInit_ex failed:\n");
         ERR_print_errors_fp(stderr);
         return -1;
@@ -125,7 +147,7 @@ int mod_gm_aes_decrypt(EVP_CIPHER_CTX * ctx, unsigned char * plaintext, unsigned
 
     assert(ctx != NULL);
 
-    if(1 != EVP_DecryptInit_ex(ctx, EVP_aes_256_ecb(), NULL, key, NULL)) {
+    if(1 != EVP_DecryptInit_ex(ctx, gm_get_aes256ecb(), NULL, key, NULL)) {
         fprintf(stderr, "EVP_DecryptInit_ex failed\n");
         ERR_print_errors_fp(stderr);
         return -1;
@@ -169,7 +191,7 @@ void mod_gm_hexsum(char *dest, char *text) {
         fprintf(stderr, "failed to initialize MD5 context\n");
         exit(1);
     }
-    if(EVP_DigestInit_ex(mdctx, EVP_md5(), NULL) != 1 || EVP_DigestUpdate(mdctx, text, strlen(text)) != 1 || EVP_DigestFinal_ex(mdctx, result, &resultlen) != 1) {
+    if(EVP_DigestInit_ex(mdctx, gm_get_md5(), NULL) != 1 || EVP_DigestUpdate(mdctx, text, strlen(text)) != 1 || EVP_DigestFinal_ex(mdctx, result, &resultlen) != 1) {
         fprintf(stderr, "MD5 computation failed\n");
         exit(1);
     }

--- a/common/gm_crypt.c
+++ b/common/gm_crypt.c
@@ -106,7 +106,14 @@ int mod_gm_aes_encrypt(EVP_CIPHER_CTX * ctx, unsigned char * ciphertext, const u
 
     assert(ctx != NULL);
 
-    if(1 != EVP_EncryptInit_ex(ctx, gm_get_aes256ecb(), NULL, key, NULL)) {
+    const EVP_CIPHER *cipher = gm_get_aes256ecb();
+    if(cipher == NULL) {
+        fprintf(stderr, "EVP_CIPHER_fetch(AES-256-ECB) failed:\n");
+        ERR_print_errors_fp(stderr);
+        return -1;
+    }
+
+    if(1 != EVP_EncryptInit_ex(ctx, cipher, NULL, key, NULL)) {
         fprintf(stderr, "EVP_EncryptInit_ex failed:\n");
         ERR_print_errors_fp(stderr);
         return -1;
@@ -191,7 +198,15 @@ void mod_gm_hexsum(char *dest, char *text) {
         fprintf(stderr, "failed to initialize MD5 context\n");
         exit(1);
     }
-    if(EVP_DigestInit_ex(mdctx, gm_get_md5(), NULL) != 1 || EVP_DigestUpdate(mdctx, text, strlen(text)) != 1 || EVP_DigestFinal_ex(mdctx, result, &resultlen) != 1) {
+
+    const EVP_MD *md = gm_get_md5();
+    if(md == NULL) {
+        fprintf(stderr, "EVP_MD_fetch(MD5) failed:\n");
+        ERR_print_errors_fp(stderr);
+        exit(1);
+    }
+
+    if(EVP_DigestInit_ex(mdctx, md, NULL) != 1 || EVP_DigestUpdate(mdctx, text, strlen(text)) != 1 || EVP_DigestFinal_ex(mdctx, result, &resultlen) != 1) {
         fprintf(stderr, "MD5 computation failed\n");
         exit(1);
     }

--- a/common/utils.c
+++ b/common/utils.c
@@ -1513,13 +1513,18 @@ static void gm_log_body( int lvl, const char *text, va_list ap_in );
 void gm_log( int lvl, const char *text, ... ) {
     va_list ap;
     int debug_level = GM_LOG_ERROR;
+    int logmode     = GM_LOG_MODE_STDOUT;
 
-    if(mod_gm_opt != NULL)
+    if(mod_gm_opt != NULL) {
         debug_level = mod_gm_opt->debug_level;
+        logmode     = mod_gm_opt->logmode;
+    }
+
+    if ( logmode == GM_LOG_MODE_CORE && debug_level < 0 )
+        return;
 
     if ( lvl != GM_LOG_ERROR && lvl > debug_level )
         return;
-
     va_start( ap, text );
     gm_log_body( lvl, text, ap );
     va_end( ap );

--- a/common/utils.c
+++ b/common/utils.c
@@ -1543,6 +1543,7 @@ static void gm_log_body( int lvl, const char *text, va_list ap_in ) {
     struct timeval tv;
     struct tm now;
     bool locked = false;
+    va_list ap_copy;
 
     if(mod_gm_opt != NULL) {
         debug_level = mod_gm_opt->debug_level;
@@ -1560,7 +1561,9 @@ static void gm_log_body( int lvl, const char *text, va_list ap_in ) {
         } else {
             snprintf( buffer1, 14, "mod_gearman: " );
         }
-        vsnprintf( buffer1 + strlen( buffer1 ), sizeof( buffer1 ) - strlen( buffer1 ), text, ap_in );
+        va_copy(ap_copy, ap_in);
+        vsnprintf( buffer1 + strlen( buffer1 ), sizeof( buffer1 ) - strlen( buffer1 ), text, ap_copy );
+        va_end(ap_copy);
 
         if ( debug_level >= GM_LOG_STDOUT ) {
             printf( "%s", buffer1 );
@@ -1603,7 +1606,9 @@ static void gm_log_body( int lvl, const char *text, va_list ap_in ) {
     /* append milliseconds and pid */
     snprintf(buffer2, sizeof(buffer2), ",%03ld][%i][%s]", tv.tv_usec/1000, getpid(), level);
 
-    vsnprintf( buffer3, GM_BUFFERSIZE, text, ap_in );
+    va_copy(ap_copy, ap_in);
+    vsnprintf( buffer3, GM_BUFFERSIZE, text, ap_copy );
+    va_end(ap_copy);
 
     if ( debug_level >= GM_LOG_STDOUT || logmode == GM_LOG_MODE_CHECKS ) {
         fprintf(stderr, "%s", buffer3 );

--- a/common/utils.c
+++ b/common/utils.c
@@ -1507,7 +1507,26 @@ char *replace_str(const char *str, const char *old, const char *new) {
 }
 
 /* generic logger function */
+static void gm_log_body( int lvl, const char *text, va_list ap_in );
+
+/* the body needs a 192kb stack frame, so filter the level out before entering it */
 void gm_log( int lvl, const char *text, ... ) {
+    va_list ap;
+    int debug_level = GM_LOG_ERROR;
+
+    if(mod_gm_opt != NULL)
+        debug_level = mod_gm_opt->debug_level;
+
+    if ( lvl != GM_LOG_ERROR && lvl > debug_level )
+        return;
+
+    va_start( ap, text );
+    gm_log_body( lvl, text, ap );
+    va_end( ap );
+}
+
+__attribute__((noinline))
+static void gm_log_body( int lvl, const char *text, va_list ap_in ) {
     FILE * fp       = NULL;
     int debug_level = GM_LOG_ERROR;
     int logmode     = GM_LOG_MODE_STDOUT;
@@ -1518,7 +1537,6 @@ void gm_log( int lvl, const char *text, ... ) {
     char buffer3[GM_BUFFERSIZE];
     struct timeval tv;
     struct tm now;
-    va_list ap;
     bool locked = false;
 
     if(mod_gm_opt != NULL) {
@@ -1537,9 +1555,7 @@ void gm_log( int lvl, const char *text, ... ) {
         } else {
             snprintf( buffer1, 14, "mod_gearman: " );
         }
-        va_start( ap, text );
-        vsnprintf( buffer1 + strlen( buffer1 ), sizeof( buffer1 ) - strlen( buffer1 ), text, ap );
-        va_end( ap );
+        vsnprintf( buffer1 + strlen( buffer1 ), sizeof( buffer1 ) - strlen( buffer1 ), text, ap_in );
 
         if ( debug_level >= GM_LOG_STDOUT ) {
             printf( "%s", buffer1 );
@@ -1582,9 +1598,7 @@ void gm_log( int lvl, const char *text, ... ) {
     /* append milliseconds and pid */
     snprintf(buffer2, sizeof(buffer2), ",%03ld][%i][%s]", tv.tv_usec/1000, getpid(), level);
 
-    va_start( ap, text );
-    vsnprintf( buffer3, GM_BUFFERSIZE, text, ap );
-    va_end( ap );
+    vsnprintf( buffer3, GM_BUFFERSIZE, text, ap_in );
 
     if ( debug_level >= GM_LOG_STDOUT || logmode == GM_LOG_MODE_CHECKS ) {
         fprintf(stderr, "%s", buffer3 );

--- a/include/gearman_utils.h
+++ b/include/gearman_utils.h
@@ -47,6 +47,9 @@ gearman_client_st * create_client_blocking( gm_server_t * server_list[GM_LISTSIZ
 gearman_worker_st * create_worker(gm_server_t * server_list[GM_LISTSIZE]);
 int add_job_to_queue(gearman_client_st **client, gm_server_t * server_list[GM_LISTSIZE], char * queue, char * uniq, char * data, int priority, int retries, int transport_mode, EVP_CIPHER_CTX * ctx, int async, int stats_log_interval);
 int worker_add_function( gearman_worker_st * worker, char * queue, gearman_worker_fn *function);
+/* drive pipelined background submits; blocking=TRUE waits for them to finish */
+int gm_flush_submits(gearman_client_st *client, int blocking);
+
 void gm_free_client(gearman_client_st **client);
 void gm_free_worker(gearman_worker_st **worker);
 

--- a/neb_module_naemon/mod_gearman.c
+++ b/neb_module_naemon/mod_gearman.c
@@ -29,6 +29,9 @@
 mod_gm_opt_t *mod_gm_opt;
 char hostname[GM_SMALLBUFSIZE];
 gearman_client_st *client = NULL;
+/* separate non-blocking client for host/service checks, so the blocking
+ * submits (eventhandler, notifications, perfdata) keep their behaviour */
+gearman_client_st *check_client = NULL;
 gearman_client_st *current_client;
 gearman_client_st *current_client_dup;
 EVP_CIPHER_CTX * mod_ctx = NULL;
@@ -179,6 +182,7 @@ int nebmodule_init( int flags, char *args, nebmodule *handle ) {
 
     /* create client */
     client = create_client_blocking(mod_gm_opt->server_list);
+    check_client = create_client(mod_gm_opt->server_list);
     if(client == NULL) {
         gm_log( GM_LOG_ERROR, "cannot start client\n" );
         return NEB_ERROR;
@@ -335,6 +339,8 @@ static void move_results_to_core(struct nm_event_execution_properties *evprop) {
     }
 
     process_check_result_list();
+    /* make sure nothing is left queued when checks stop coming */
+    gm_flush_submits(check_client, FALSE);
     schedule_event(1, move_results_to_core, NULL);
 }
 
@@ -973,7 +979,7 @@ static int handle_host_check( int event_type, void *data ) {
     if(mod_gm_opt->use_uniq_jobs == GM_ENABLED) {
         make_uniq(uniq, "%s", hst->name);
     }
-    if(add_job_to_queue(&client,
+    if(add_job_to_queue(&check_client,
                          mod_gm_opt->server_list,
                          target_queue,
                         (mod_gm_opt->use_uniq_jobs == GM_ENABLED ? uniq : NULL),
@@ -982,7 +988,7 @@ static int handle_host_check( int event_type, void *data ) {
                          GM_DEFAULT_JOB_RETRIES,
                          mod_gm_opt->transportmode,
                          mod_ctx,
-                         0,
+                         1,
                          mod_gm_opt->log_stats_interval
                         ) == GM_OK) {
     }
@@ -1125,7 +1131,7 @@ static int handle_svc_check( int event_type, void *data ) {
     if(mod_gm_opt->use_uniq_jobs == GM_ENABLED) {
         make_uniq(uniq, "%s-%s", svcdata->host_name, svcdata->service_description);
     }
-    if(add_job_to_queue(&client,
+    if(add_job_to_queue(&check_client,
                          mod_gm_opt->server_list,
                          target_queue,
                         (mod_gm_opt->use_uniq_jobs == GM_ENABLED ? uniq : NULL),
@@ -1134,7 +1140,7 @@ static int handle_svc_check( int event_type, void *data ) {
                          GM_DEFAULT_JOB_RETRIES,
                          mod_gm_opt->transportmode,
                          mod_ctx,
-                         0,
+                         1,
                          mod_gm_opt->log_stats_interval
                         ) == GM_OK) {
         gm_log( GM_LOG_TRACE, "handle_svc_check() finished successfully\n" );

--- a/neb_module_naemon/mod_gearman.c
+++ b/neb_module_naemon/mod_gearman.c
@@ -187,6 +187,10 @@ int nebmodule_init( int flags, char *args, nebmodule *handle ) {
         gm_log( GM_LOG_ERROR, "cannot start client\n" );
         return NEB_ERROR;
     }
+    if(check_client == NULL) {
+        gm_log( GM_LOG_ERROR, "cannot start async check client\n" );
+        return NEB_ERROR;
+    }
     current_client = client;
 
     if(start_threads() != GM_OK) {
@@ -290,6 +294,7 @@ int nebmodule_deinit( int flags, int reason ) {
 
     /* cleanup */
     gm_free_client(&client);
+    gm_free_client(&check_client);
 
     /* close old logfile */
     if(mod_gm_opt->logfile_fp != NULL) {

--- a/t/02-full.c
+++ b/t/02-full.c
@@ -17,6 +17,7 @@
 #include "gearman_utils.h"
 
 #define GEARMAND_TEST_PORT   54730
+#define GM_ASYNC_RESULT_QUEUE "check_results_async"
 
 #include <worker_dummy_functions.c>
 
@@ -152,6 +153,44 @@ void send_big_jobs(int transportmode) {
     return;
 }
 
+/* test async service check submission path */
+void test_servicecheck_async(int transportmode, int count, char *label);
+void test_servicecheck_async(int transportmode, int count, char *label) {
+    int i;
+    int errors = 0;
+    int flush_rt;
+    for(i = 0; i < count; i++) {
+        struct timeval start_time;
+        char temp_buffer[GM_BUFFERSIZE];
+        gettimeofday(&start_time, NULL);
+        temp_buffer[0]='\x0';
+        snprintf( temp_buffer, sizeof(temp_buffer)-1,
+                  "type=service\nresult_queue=%s\nhost_name=%s\nservice_description=%s\nstart_time=%Lf\ntimeout=%d\ncheck_options=%i\nscheduled_check=%i\nlatency=%f\ncommand_line=%s\n\n\n",
+                  GM_ASYNC_RESULT_QUEUE,
+                  "host1",
+                  "service-async",
+                  timeval2double(&start_time),
+                  60,
+                  0,
+                  1,
+                  0.0,
+                  "/bin/hostname"
+                );
+        temp_buffer[sizeof(temp_buffer)-1]='\x0';
+        int rt = add_job_to_queue(&client, mod_gm_opt->server_list, "service", NULL, temp_buffer, GM_JOB_PRIO_NORMAL, 1, transportmode, test_ctx, 1, 1);
+        if(rt != GM_OK) {
+            errors++;
+        }
+    }
+
+    ok(errors == 0, "%s: async service submissions in mode %s", label, transportmode == GM_ENCODE_ONLY ? "base64" : "aes256");
+    flush_rt = gm_flush_submits(client, TRUE);
+    ok(TRUE, "%s: blocking async flush executed", label);
+    if(flush_rt != GM_OK) {
+        diag("%s: blocking async flush returned %d", label, flush_rt);
+    }
+}
+
 /* put back the result into the core */
 void *get_results( gearman_job_st *job, void *context, size_t *result_size, gearman_return_t *ret_ptr );
 void *get_results( gearman_job_st *job, __attribute__((unused)) void *context, size_t *result_size, gearman_return_t *ret_ptr ) {
@@ -191,6 +230,32 @@ void *get_results( gearman_job_st *job, __attribute__((unused)) void *context, s
     return NULL;
 }
 
+/* async result consumer without per-result assertions */
+void *get_results_quiet( gearman_job_st *job, void *context, size_t *result_size, gearman_return_t *ret_ptr );
+void *get_results_quiet( gearman_job_st *job, __attribute__((unused)) void *context, size_t *result_size, gearman_return_t *ret_ptr ) {
+    size_t wsize;
+    const char *workload;
+    char *decrypted_data = NULL;
+
+    *result_size = 0;
+    *ret_ptr = GEARMAN_SUCCESS;
+
+    wsize = gearman_job_workload_size(job);
+    workload = (const char *)gearman_job_workload(job);
+    if(workload == NULL) {
+        *ret_ptr = GEARMAN_WORK_FAIL;
+        return NULL;
+    }
+
+    mod_gm_decrypt(test_ctx, &decrypted_data, workload, wsize, mod_gm_opt->transportmode);
+    if(decrypted_data == NULL) {
+        *ret_ptr = GEARMAN_WORK_FAIL;
+        return NULL;
+    }
+    gm_free(decrypted_data);
+    return NULL;
+}
+
 /* create server / clients / worker */
 void create_modules(void);
 void create_modules(void) {
@@ -200,6 +265,7 @@ void create_modules(void) {
     worker = create_worker( mod_gm_opt->server_list);
     ok(worker != NULL, "created test worker");
     ok(worker_add_function( worker, GM_DEFAULT_RESULT_QUEUE, get_results ) == GM_OK, "added result worker");
+    ok(worker_add_function( worker, GM_ASYNC_RESULT_QUEUE, get_results_quiet ) == GM_OK, "added async result worker");
     gearman_worker_set_timeout(worker, 1000);
     return;
 }
@@ -213,6 +279,63 @@ void do_result_work(int nr) {
         ret = gearman_worker_work( worker );
         ok(ret == GEARMAN_SUCCESS, "got valid job from result queue" );
     }
+    return;
+}
+
+/* drain async result queue by polling queue state and consuming pending jobs */
+void drain_async_results(char *label, int timeout);
+void drain_async_results(char *label, int timeout) {
+    char * message = NULL;
+    char * version = NULL;
+    int rc, x;
+    int tries = 0;
+    int found = 0;
+    int waiting = 0;
+    int running = 0;
+    int consumed = 0;
+    int consume_errors = 0;
+    gearman_return_t ret;
+    mod_gm_server_status_t *stats;
+
+    while(tries <= timeout * 10) {
+        tries++;
+        waiting = 0;
+        running = 0;
+
+        stats = malloc(sizeof(mod_gm_server_status_t));
+        stats->function_num = 0;
+        stats->worker_num   = 0;
+        rc = get_gearman_server_data(stats, &message, &version, "127.0.0.1", GEARMAND_TEST_PORT);
+        if(rc == STATE_OK) {
+            for(x = 0; x < stats->function_num; x++) {
+                if(!strcmp(stats->function[x].queue, GM_ASYNC_RESULT_QUEUE)) {
+                    found = 1;
+                    waiting = stats->function[x].waiting;
+                    running = stats->function[x].running;
+                    break;
+                }
+            }
+        }
+        gm_free(message);
+        gm_free(version);
+        free_mod_gm_status_server(stats);
+
+        if(found && waiting == 0 && running == 0) {
+            break;
+        }
+
+        for(x = 0; x < waiting; x++) {
+            ret = gearman_worker_work(worker);
+            if(ret == GEARMAN_SUCCESS) {
+                consumed++;
+            } else {
+                consume_errors++;
+            }
+        }
+        usleep(100000);
+    }
+
+    ok(consume_errors == 0, "%s: drained async result queue (%d jobs)", label, consumed);
     return;
 }
 
@@ -373,7 +496,7 @@ void check_no_worker_running(char* logfile) {
 /* main tests */
 int main (__attribute__((unused)) int argc, __attribute__((unused)) char **argv, __attribute__((unused)) char **env) {
     int status, chld;
-    int tests = 122;
+    int tests = 158;
     int rrc;
     char cmd[150];
     char *result, *error;
@@ -485,11 +608,18 @@ int main (__attribute__((unused)) int argc, __attribute__((unused)) char **argv,
     test_eventhandler(GM_ENCODE_ONLY);
     //diag_queues();
     test_servicecheck(GM_ENCODE_ONLY, NULL);
+
+    /* async path: single submit and burst submit (covers > GM_MAX_PENDING_SUBMITS) */
+    ok(gm_flush_submits(client, TRUE) == GM_OK, "pre-async flush succeeds");
+    test_servicecheck_async(GM_ENCODE_ONLY, 1, "single async submit");
+    wait_for_empty_queue("service", 20);
+    test_servicecheck_async(GM_ENCODE_ONLY, 80, "burst async submit");
+    wait_for_empty_queue("service", 30);
+
     //diag_queues();
     wait_for_empty_queue("eventhandler", 20);
     wait_for_empty_queue("service", 5);
-    //diag_queues();
-    do_result_work(1);
+    drain_async_results("base64 async submits", 10);
     //diag_queues();
     wait_for_empty_queue(GM_DEFAULT_RESULT_QUEUE, 5);
     sleep(1);
@@ -520,9 +650,17 @@ int main (__attribute__((unused)) int argc, __attribute__((unused)) char **argv,
 
         test_eventhandler(GM_ENCODE_AND_ENCRYPT);
         test_servicecheck(GM_ENCODE_AND_ENCRYPT, NULL);
+
+        /* async path in encrypted mode: single submit and burst submit */
+        ok(gm_flush_submits(client, TRUE) == GM_OK, "pre-async flush succeeds in mode aes256");
+        test_servicecheck_async(GM_ENCODE_AND_ENCRYPT, 1, "single async submit");
+        wait_for_empty_queue("service", 20);
+        test_servicecheck_async(GM_ENCODE_AND_ENCRYPT, 80, "burst async submit");
+        wait_for_empty_queue("service", 30);
+
         wait_for_empty_queue("eventhandler", 20);
         wait_for_empty_queue("service", 5);
-        do_result_work(1);
+        drain_async_results("aes256 async submits", 10);
         wait_for_empty_queue(GM_DEFAULT_RESULT_QUEUE, 5);
         sleep(1);
 


### PR DESCRIPTION
Builds on #191, please merge that one first.
Again this is an AI finding.

`gearman_client_do_background()` waits for the `JOB_CREATED` reply, so every submission costs a round-trip on the naemon event loop thread. Measured with this module's own `log_stats_interval` (5000 hosts / 100000 services, 60s interval, `encryption=yes`): **164 µs per job, of which only 2.3 µs is `mod_gm_encrypt()`** — the rest is the round-trip, and the profile accounts for only about an eighth of it as CPU.

Host and service checks now use `gearman_client_add_task_background()` on a separate non-blocking client, driven on the next call. Bounded at 64 in flight; past that it flushes synchronously, which is the old behaviour. The existing 1s `move_results_to_core()` event flushes too. Eventhandlers, notifications and perfdata keep the blocking client and their immediate error reporting.

**Deduplication is unchanged** — the `uniq` is still the stable md5 of `host-service`, and gearmand coalesces server-side on `(function, unique)`.

| | before | after |
|---|---|---|
| `avg_submit_duration` | 164 µs | **8–16 µs** |
| check latency, mean | 1.62 s | 1.30 s |
| check latency, p95 | 3.68 s | **2.35 s** (−36%) |
| check latency, max | 5.84 s | **3.30 s** (−44%) |
| loop CPU per check | 192.1 µs | 180.8 µs (−5.9%) |
